### PR TITLE
Fixed dead links in the simulator tutoril notebook

### DIFF
--- a/notebooks/Running-Simulations.ipynb
+++ b/notebooks/Running-Simulations.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "## Ingredients\n",
     "\n",
-    "The [Simulation Standard documentation](http://juliapomdp.github.io/POMDPs.jl/latest/simulation.html) gives information about ingredients to a simulation. The minimum requirement is for a `POMDP` or `MDP` model and a `Policy`.\n",
+    "The [Simulation Standard documentation](https://juliapomdp.github.io/POMDPs.jl/stable/simulation) gives information about ingredients to a simulation. The minimum requirement is for a `POMDP` or `MDP` model and a `Policy`.\n",
     "\n",
     "Models from the [POMDPModels package](https://github.com/JuliaPOMDP/POMDPModels.jl) and policies from the [POMDPPolicies package](https://github.com/JuliaPOMDP/POMDPPolicies.jl) will be used in these examples. For more information on defining models, see the tutorials about defining POMDPs and MDPs; for information on hand-specifying policies see the Heuristic Policies tutorial [TODO: add link]; and for examples of solving for policies, see the tutorials about solving POMDPs online and offline [TODO: add link]. Also consult the docstrings for the various functions used here."
    ]

--- a/notebooks/Running-Simulations.ipynb
+++ b/notebooks/Running-Simulations.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "All simulators in POMDPs.jl should be consistent with the [Simulation Standard](https://juliapomdp.github.io/POMDPs.jl/stable/simulation), and the Simulation Standard document should be consulted to answer questions about how a simulation is defined.\n",
     "\n",
-    "There are several ways to perform simulations in the POMDPs.jl ecosystem. The [POMDPSimulators package](https://github.com/JuliaPOMDP/POMDPSimulators.jl) provides implementations of several simulators and [a page to help decide which to use](https://juliapomdp.github.io/POMDPSimulators.jl/latest/which.html). This tutorial will show a few examples demonstrating how to use the simulators, but the POMDPSimulators documentation serves as a more in-depth reference.\n",
+    "There are several ways to perform simulations in the POMDPs.jl ecosystem. The [POMDPSimulators package](https://github.com/JuliaPOMDP/POMDPSimulators.jl) provides implementations of several simulators and [a page to help decide which to use](https://juliapomdp.github.io/POMDPSimulators.jl/latest/which). This tutorial will show a few examples demonstrating how to use the simulators, but the POMDPSimulators documentation serves as a more in-depth reference.\n",
     "\n",
     "## Ingredients\n",
     "\n",

--- a/notebooks/Running-Simulations.ipynb
+++ b/notebooks/Running-Simulations.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Running Simulations\n",
     "\n",
-    "All simulators in POMDPs.jl should be consistent with the [Simulation Standard](http://juliapomdp.github.io/POMDPs.jl/latest/simulation.html), and the Simulation Standard document should be consulted to answer questions about how a simulation is defined.\n",
+    "All simulators in POMDPs.jl should be consistent with the [Simulation Standard](https://juliapomdp.github.io/POMDPs.jl/stable/simulation), and the Simulation Standard document should be consulted to answer questions about how a simulation is defined.\n",
     "\n",
     "There are several ways to perform simulations in the POMDPs.jl ecosystem. The [POMDPSimulators package](https://github.com/JuliaPOMDP/POMDPSimulators.jl) provides implementations of several simulators and [a page to help decide which to use](https://juliapomdp.github.io/POMDPSimulators.jl/latest/which.html). This tutorial will show a few examples demonstrating how to use the simulators, but the POMDPSimulators documentation serves as a more in-depth reference.\n",
     "\n",

--- a/notebooks/Running-Simulations.ipynb
+++ b/notebooks/Running-Simulations.ipynb
@@ -103,7 +103,7 @@
    "source": [
     "## Rollout Simulations\n",
     "\n",
-    "While `stepthrough` is a flexible and convenient tool for many user-facing demonstration, it is often less error-prone to use the standard [`simulate`](http://juliapomdp.github.io/POMDPs.jl/latest/api.html#POMDPs.simulate) function with a [`Simulator`](http://juliapomdp.github.io/POMDPs.jl/latest/concepts.html#Simulators-1) object. The simplest `Simulator` is the [`RolloutSimulator`](https://juliapomdp.github.io/POMDPSimulators.jl/latest/rollout.html#POMDPSimulators.RolloutSimulator). It simply runs a simulation as fast as possible and returns the discounted reward. Note that discounted reward for the simulation with the larger number of steps approaches the theoretical reward for a policy of always listening, $\\Sigma_{t=0}^\\infty -5 \\gamma^t$."
+    "While `stepthrough` is a flexible and convenient tool for many user-facing demonstration, it is often less error-prone to use the standard [`simulate`](http://juliapomdp.github.io/POMDPs.jl/latest/api#POMDPs.simulate) function with a [`Simulator`](http://juliapomdp.github.io/POMDPs.jl/latest/concepts#Simulators-1) object. The simplest `Simulator` is the [`RolloutSimulator`](https://juliapomdp.github.io/POMDPSimulators.jl/latest/rollout#POMDPSimulators.RolloutSimulator). It simply runs a simulation as fast as possible and returns the discounted reward. Note that discounted reward for the simulation with the larger number of steps approaches the theoretical reward for a policy of always listening, $\\Sigma_{t=0}^\\infty -5 \\gamma^t$."
    ]
   },
   {
@@ -135,7 +135,7 @@
    "source": [
     "## Recording Histories\n",
     "\n",
-    "Sometimes it is important to record the entire history of a simulation for further examination. This can be accomplished with a [`HistoryRecorder`](https://juliapomdp.github.io/POMDPSimulators.jl/latest/history_recorder.html#POMDPSimulators.HistoryRecorder). "
+    "Sometimes it is important to record the entire history of a simulation for further examination. This can be accomplished with a [`HistoryRecorder`](https://juliapomdp.github.io/POMDPSimulators.jl/latest/history_recorder#POMDPSimulators.HistoryRecorder). "
    ]
   },
   {
@@ -154,7 +154,7 @@
    "source": [
     "### Histories\n",
     "\n",
-    "The history object produced by a `HistoryRecorder` is a [`SimHistory`, documented in the POMDPSimulators package](https://juliapomdp.github.io/POMDPSimulators.jl/latest/histories.html#Histories-1). The information in this object can be accessed in several ways. For example, there is a function:"
+    "The history object produced by a `HistoryRecorder` is a [`SimHistory`, documented in the POMDPSimulators package](https://juliapomdp.github.io/POMDPSimulators.jl/latest/histories#Histories-1). The information in this object can be accessed in several ways. For example, there is a function:"
    ]
   },
   {
@@ -211,7 +211,7 @@
     "\n",
     "### `eachstep`\n",
     "\n",
-    "The most powerful function for accessing the information in a `SimHistory` is the [`eachstep` function](https://juliapomdp.github.io/POMDPSimulators.jl/latest/histories.html#POMDPSimulators.eachstep) which returns an iterator through [`NamedTuple`](https://docs.julialang.org/en/v1/manual/types/index.html#Named-Tuple-Types-1)s representing each step in the history. The `eachstep` function is similar to the `stepthrough` function above except that it iterates through the immutable steps of a previously simulated history instead of conducting the simulation as the for loop is being carried out."
+    "The most powerful function for accessing the information in a `SimHistory` is the [`eachstep` function](https://juliapomdp.github.io/POMDPSimulators.jl/latest/histories#POMDPSimulators.eachstep) which returns an iterator through [`NamedTuple`](https://docs.julialang.org/en/v1/manual/types/index.html#Named-Tuple-Types-1)s representing each step in the history. The `eachstep` function is similar to the `stepthrough` function above except that it iterates through the immutable steps of a previously simulated history instead of conducting the simulation as the for loop is being carried out."
    ]
   },
   {
@@ -454,7 +454,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [`sim` function](https://juliapomdp.github.io/POMDPSimulators.jl/latest/sim.html) provides a convenient way to interact with a `POMDP` or `MDP` environment from the perspective of an agent acting in that environment."
+    "The [`sim` function](https://juliapomdp.github.io/POMDPSimulators.jl/latest/sim) provides a convenient way to interact with a `POMDP` or `MDP` environment from the perspective of an agent acting in that environment."
    ]
   },
   {

--- a/notebooks/Running-Simulations.ipynb
+++ b/notebooks/Running-Simulations.ipynb
@@ -58,7 +58,7 @@
    "source": [
     "## Stepthrough\n",
     "\n",
-    "The recommended first way to try out POMDPs.jl simulations is with the [`stepthrough` function](https://juliapomdp.github.io/POMDPSimulators.jl/latest/stepthrough.html). This function provides a window into the simulation with a for-loop syntax.\n",
+    "The recommended first way to try out POMDPs.jl simulations is with the [`stepthrough` function](https://juliapomdp.github.io/POMDPSimulators.jl/latest/stepthrough/#POMDPSimulators.stepthrough). This function provides a window into the simulation with a for-loop syntax.\n",
     "\n",
     "Within the body of the for loop, we have access to the belief, `b`, the action, `a`, the observation, `o`, and the reward, `r`, in each step. As more information is gathered through listening, confidence about whether the tiger is in the left or right door increases dramatically. The sum of the rewards is also calculated here, but note that this is *not the discounted reward*."
    ]

--- a/notebooks/Running-Simulations.ipynb
+++ b/notebooks/Running-Simulations.ipynb
@@ -6,13 +6,13 @@
    "source": [
     "# Running Simulations\n",
     "\n",
-    "All simulators in POMDPs.jl should be consistent with the [Simulation Standard](https://juliapomdp.github.io/POMDPs.jl/stable/simulation), and the Simulation Standard document should be consulted to answer questions about how a simulation is defined.\n",
+    "All simulators in POMDPs.jl should be consistent with the [Simulation Standard](https://juliapomdp.github.io/POMDPs.jl/latest/simulation), and the Simulation Standard document should be consulted to answer questions about how a simulation is defined.\n",
     "\n",
     "There are several ways to perform simulations in the POMDPs.jl ecosystem. The [POMDPSimulators package](https://github.com/JuliaPOMDP/POMDPSimulators.jl) provides implementations of several simulators and [a page to help decide which to use](https://juliapomdp.github.io/POMDPSimulators.jl/latest/which). This tutorial will show a few examples demonstrating how to use the simulators, but the POMDPSimulators documentation serves as a more in-depth reference.\n",
     "\n",
     "## Ingredients\n",
     "\n",
-    "The [Simulation Standard documentation](https://juliapomdp.github.io/POMDPs.jl/stable/simulation) gives information about ingredients to a simulation. The minimum requirement is for a `POMDP` or `MDP` model and a `Policy`.\n",
+    "The [Simulation Standard documentation](https://juliapomdp.github.io/POMDPs.jl/latest/simulation) gives information about ingredients to a simulation. The minimum requirement is for a `POMDP` or `MDP` model and a `Policy`.\n",
     "\n",
     "Models from the [POMDPModels package](https://github.com/JuliaPOMDP/POMDPModels.jl) and policies from the [POMDPPolicies package](https://github.com/JuliaPOMDP/POMDPPolicies.jl) will be used in these examples. For more information on defining models, see the tutorials about defining POMDPs and MDPs; for information on hand-specifying policies see the Heuristic Policies tutorial [TODO: add link]; and for examples of solving for policies, see the tutorials about solving POMDPs online and offline [TODO: add link]. Also consult the docstrings for the various functions used here."
    ]
@@ -103,7 +103,7 @@
    "source": [
     "## Rollout Simulations\n",
     "\n",
-    "While `stepthrough` is a flexible and convenient tool for many user-facing demonstration, it is often less error-prone to use the standard [`simulate`](http://juliapomdp.github.io/POMDPs.jl/latest/api#POMDPs.simulate) function with a [`Simulator`](http://juliapomdp.github.io/POMDPs.jl/latest/concepts#Simulators-1) object. The simplest `Simulator` is the [`RolloutSimulator`](https://juliapomdp.github.io/POMDPSimulators.jl/latest/rollout#POMDPSimulators.RolloutSimulator). It simply runs a simulation as fast as possible and returns the discounted reward. Note that discounted reward for the simulation with the larger number of steps approaches the theoretical reward for a policy of always listening, $\\Sigma_{t=0}^\\infty -5 \\gamma^t$."
+    "While `stepthrough` is a flexible and convenient tool for many user-facing demonstration, it is often less error-prone to use the standard [`simulate`](https://juliapomdp.github.io/POMDPs.jl/latest/api#POMDPs.simulate) function with a [`Simulator`](https://juliapomdp.github.io/POMDPs.jl/latest/concepts#Simulators-1) object. The simplest `Simulator` is the [`RolloutSimulator`](https://juliapomdp.github.io/POMDPSimulators.jl/latest/rollout#POMDPSimulators.RolloutSimulator). It simply runs a simulation as fast as possible and returns the discounted reward. Note that discounted reward for the simulation with the larger number of steps approaches the theoretical reward for a policy of always listening, $\\Sigma_{t=0}^\\infty -5 \\gamma^t$."
    ]
   },
   {


### PR DESCRIPTION
While trying to figure out how to setup simulations, I encountered some dead links in the tutorial notebook. They should be fixed in this PR.